### PR TITLE
[FE] #44 - [FE] Implement Right-Side Filter Sidebar Component

### DIFF
--- a/src/components/FilterSidebar.css
+++ b/src/components/FilterSidebar.css
@@ -1,0 +1,47 @@
+.filter-sidebar {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 280px;
+  height: 100%;
+  background: #fff;
+  border-left: 1px solid #ddd;
+  box-shadow: -2px 0 4px rgba(0,0,0,0.04);
+  transition: width 0.3s;
+  z-index: 100;
+  overflow-x: hidden;
+}
+.filter-sidebar.collapsed {
+  width: 40px;
+}
+.sidebar-toggle {
+  position: absolute;
+  left: -32px;
+  top: 20px;
+  width: 32px;
+  height: 32px;
+  background: #f3f3f3;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  font-size: 20px;
+  cursor: pointer;
+}
+.filter-panel {
+  padding: 32px 12px 16px 12px;
+}
+.filter-section {
+  margin-bottom: 18px;
+}
+.filter-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0;
+}
+.filter-section li {
+  margin: 4px 0;
+}
+.count {
+  color: #888;
+  font-size: 0.85em;
+  margin-left: 4px;
+}

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import './FilterSidebar.css';
+
+const AUCTION_TYPES = ['NAV', 'EER', 'MNV'];
+const AUCTION_STATUSES = ['active', 'expired'];
+
+export interface FilterState {
+  types: string[];
+  statuses: string[];
+}
+
+interface FilterSidebarProps {
+  auctionData: any[]; // unified model from Issue #8
+  onFilter: (filters: FilterState) => void;
+}
+
+const FILTER_STATE_KEY = 'auctionMapFilterSidebar';
+
+function getCounts(data: any[], field: string, options: string[]): { [option: string]: number } {
+  const counts: { [option: string]: number } = {};
+  for (const option of options) {
+    counts[option] = data.filter(item => item[field] === option).length;
+  }
+  return counts;
+}
+
+export const FilterSidebar: React.FC<FilterSidebarProps> = ({ auctionData, onFilter }) => {
+  const [collapsed, setCollapsed] = useState(false);
+  const [filters, setFilters] = useState<FilterState>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(FILTER_STATE_KEY) || '') || {
+        types: AUCTION_TYPES,
+        statuses: AUCTION_STATUSES
+      };
+    } catch {
+      return {
+        types: AUCTION_TYPES,
+        statuses: AUCTION_STATUSES
+      };
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(FILTER_STATE_KEY, JSON.stringify(filters));
+    onFilter(filters);
+  }, [filters, onFilter]);
+
+  // Counts
+  const typeCounts = getCounts(auctionData, 'type', AUCTION_TYPES);
+  const statusCounts = getCounts(auctionData, 'status', AUCTION_STATUSES);
+
+  const toggleCollapsed = () => setCollapsed(c => !c);
+
+  const handleTypeToggle = (type: string) => {
+    setFilters(prev => ({
+      ...prev,
+      types: prev.types.includes(type) ? prev.types.filter(t => t !== type) : [...prev.types, type],
+    }));
+  };
+
+  const handleStatusToggle = (status: string) => {
+    setFilters(prev => ({
+      ...prev,
+      statuses: prev.statuses.includes(status) ? prev.statuses.filter(s => s !== status) : [...prev.statuses, status],
+    }));
+  };
+
+  return (
+    <div className={`filter-sidebar${collapsed ? ' collapsed' : ''}`}> 
+      <button className="sidebar-toggle" onClick={toggleCollapsed} title={collapsed ? 'Expand' : 'Collapse'}>{collapsed ? '▶️' : '◀️'}</button>
+      {!collapsed && (
+        <div className="filter-panel">
+          <h3>Filter Auctions</h3>
+          <div className="filter-section">
+            <strong>Type</strong>
+            <ul>
+              {AUCTION_TYPES.map(type => (
+                <li key={type}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={filters.types.includes(type)}
+                      onChange={() => handleTypeToggle(type)}
+                    />
+                    {type} <span className="count">({typeCounts[type]})</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="filter-section">
+            <strong>Status</strong>
+            <ul>
+              {AUCTION_STATUSES.map(status => (
+                <li key={status}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={filters.statuses.includes(status)}
+                      onChange={() => handleStatusToggle(status)}
+                    />
+                    {status.charAt(0).toUpperCase() + status.slice(1)} <span className="count">({statusCounts[status]})</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {/* Extendable: add other filter fields here */}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/__tests__/FilterSidebar.test.tsx
+++ b/src/components/__tests__/FilterSidebar.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { FilterSidebar, FilterState } from '../FilterSidebar';
+
+const sampleData = [
+  { type: 'NAV', status: 'active' },
+  { type: 'NAV', status: 'expired' },
+  { type: 'MNV', status: 'active' },
+  { type: 'EER', status: 'active' },
+  { type: 'EER', status: 'expired' }
+];
+
+describe('FilterSidebar', () => {
+  it('renders all filter options and counts', () => {
+    const onFilter = jest.fn();
+    const { getByText } = render(
+      <FilterSidebar auctionData={sampleData} onFilter={onFilter} />
+    );
+    expect(getByText('NAV (2)')).toBeInTheDocument();
+    expect(getByText('EER (2)')).toBeInTheDocument();
+    expect(getByText('MNV (1)')).toBeInTheDocument();
+    expect(getByText('Active (3)')).toBeInTheDocument();
+    expect(getByText('Expired (2)')).toBeInTheDocument();
+  });
+
+  it('toggles filters and persists in localStorage', () => {
+    const onFilter = jest.fn();
+    const { getByLabelText } = render(
+      <FilterSidebar auctionData={sampleData} onFilter={onFilter} />
+    );
+    const navCheckbox = getByLabelText('NAV (2)');
+    fireEvent.click(navCheckbox);
+    expect(onFilter).toHaveBeenCalledWith(expect.objectContaining({ types: expect.not.arrayContaining(['NAV']) }));
+    // localStorage check
+    expect(JSON.parse(window.localStorage.getItem('auctionMapFilterSidebar'))).not.toEqual(expect.objectContaining({ types: expect.arrayContaining(['NAV']) }));
+  });
+
+  it('collapses and expands sidebar', () => {
+    const onFilter = jest.fn();
+    const { getByTitle } = render(
+      <FilterSidebar auctionData={sampleData} onFilter={onFilter} />
+    );
+    const toggleBtn = getByTitle('Collapse');
+    fireEvent.click(toggleBtn);
+    expect(getByTitle('Expand')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #44

Implements a collapsible filter sidebar for auction filtering, includes auction type/status toggles, count display, session persistence, immediate filter response. All acceptance criteria covered. Contains tests.
